### PR TITLE
Adding fields for Shopify Store and Vector Database

### DIFF
--- a/app/controllers/api/v1/accounts_controller.rb
+++ b/app/controllers/api/v1/accounts_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def update
-    @account.assign_attributes(account_params.slice(:name, :locale, :domain, :support_email, :auto_resolve_duration))
+    @account.assign_attributes(account_params.slice(:name, :locale, :domain, :support_email, :auto_resolve_duration, :shopify_name, :vector_database_namespace))
     @account.custom_attributes.merge!(custom_attributes_params)
     @account.custom_attributes['onboarding_step'] = 'invite_team' if @account.custom_attributes['onboarding_step'] == 'account_update'
     @account.save!
@@ -83,7 +83,7 @@ class Api::V1::AccountsController < Api::BaseController
   end
 
   def account_params
-    params.permit(:account_name, :email, :name, :password, :locale, :domain, :support_email, :auto_resolve_duration, :user_full_name)
+    params.permit(:account_name, :email, :name, :password, :locale, :domain, :support_email, :auto_resolve_duration, :user_full_name, :shopify_name, :vector_database_namespace)
   end
 
   def custom_attributes_params

--- a/app/controllers/platform/api/v1/accounts_controller.rb
+++ b/app/controllers/platform/api/v1/accounts_controller.rb
@@ -38,6 +38,6 @@ class Platform::Api::V1::AccountsController < PlatformController
   end
 
   def permitted_params
-    params.permit(:name, :locale, :domain, :support_email, :status, features: {}, limits: {}, custom_attributes: {})
+    params.permit(:name, :locale, :domain, :support_email, :status, :shopify_name, :vector_database_namespace, features: {}, limits: {}, custom_attributes: {})
   end
 end

--- a/app/javascript/dashboard/i18n/locale/en/generalSettings.json
+++ b/app/javascript/dashboard/i18n/locale/en/generalSettings.json
@@ -72,6 +72,24 @@
       "FEATURES": {
         "INBOUND_EMAIL_ENABLED": "Conversation continuity with emails is enabled for your account.",
         "CUSTOM_EMAIL_DOMAIN_ENABLED": "You can receive emails in your custom domain now."
+      },
+      "SHOPIFY_SECTION": {
+        "TITLE": "Shopify Integration",
+        "NOTE": "Configure your Shopify store integration"
+      },
+      "SHOPIFY_NAME": {
+        "LABEL": "Shopify Name",
+        "PLACEHOLDER": "Enter your Shopify store name",
+        "ERROR": ""
+      },
+      "VECTOR_DB_SECTION": {
+        "TITLE": "Vector Database Configuration",
+        "NOTE": "Configure your vector database settings for enhanced AI capabilities"
+      },
+      "VECTOR_DB_NAMESPACE": {
+        "LABEL": "Vector Database Namespace",
+        "PLACEHOLDER": "Enter the namespace for filtering vector database queries",
+        "ERROR": ""
       }
     },
     "UPDATE_CHATWOOT": "An update {latestChatwootVersion} for Chatwoot is available. Please update your instance.",

--- a/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
+++ b/app/javascript/dashboard/routes/dashboard/settings/account/Index.vue
@@ -40,6 +40,8 @@ export default {
       autoResolveDuration: null,
       latestChatwootVersion: null,
       showDeletePopup: false,
+      shopifyName: '',
+      vectorDatabaseNamespace: '',
     };
   },
   validations: {
@@ -151,6 +153,8 @@ export default {
           features,
           auto_resolve_duration,
           latest_chatwoot_version: latestChatwootVersion,
+          shopify_name,
+          vector_database_namespace,
         } = this.getAccount(this.accountId);
 
         this.$root.$i18n.locale = locale;
@@ -162,6 +166,8 @@ export default {
         this.features = features;
         this.autoResolveDuration = auto_resolve_duration;
         this.latestChatwootVersion = latestChatwootVersion;
+        this.shopifyName = shopify_name;
+        this.vectorDatabaseNamespace = vector_database_namespace;
       } catch (error) {
         // Ignore error
       }
@@ -180,6 +186,8 @@ export default {
           domain: this.domain,
           support_email: this.supportEmail,
           auto_resolve_duration: this.autoResolveDuration,
+          shopify_name: this.shopifyName,
+          vector_database_namespace: this.vectorDatabaseNamespace,
         });
         this.$root.$i18n.locale = this.locale;
         this.getAccount(this.id).locale = this.locale;
@@ -345,6 +353,45 @@ export default {
             </label>
           </div>
         </div>
+
+        <div class="flex flex-row border-b border-slate-25 dark:border-slate-800">
+          <div class="flex-grow-0 flex-shrink-0 flex-[25%] min-w-0 py-4 pr-6 pl-0">
+            <h4 class="text-lg font-medium text-black-900 dark:text-slate-200">
+              {{ $t('GENERAL_SETTINGS.FORM.SHOPIFY_SECTION.TITLE') }}
+            </h4>
+            <p>{{ $t('GENERAL_SETTINGS.FORM.SHOPIFY_SECTION.NOTE') }}</p>
+          </div>
+          <div class="p-4 flex-grow-0 flex-shrink-0 flex-[50%]">
+            <label>
+              {{ $t('GENERAL_SETTINGS.FORM.SHOPIFY_NAME.LABEL') }}
+              <input
+                v-model="shopifyName"
+                type="text"
+                :placeholder="$t('GENERAL_SETTINGS.FORM.SHOPIFY_NAME.PLACEHOLDER')"
+              />
+            </label>
+          </div>
+        </div>
+
+        <div class="flex flex-row border-b border-slate-25 dark:border-slate-800">
+          <div class="flex-grow-0 flex-shrink-0 flex-[25%] min-w-0 py-4 pr-6 pl-0">
+            <h4 class="text-lg font-medium text-black-900 dark:text-slate-200">
+              {{ $t('GENERAL_SETTINGS.FORM.VECTOR_DB_SECTION.TITLE') }}
+            </h4>
+            <p>{{ $t('GENERAL_SETTINGS.FORM.VECTOR_DB_SECTION.NOTE') }}</p>
+          </div>
+          <div class="p-4 flex-grow-0 flex-shrink-0 flex-[50%]">
+            <label>
+              {{ $t('GENERAL_SETTINGS.FORM.VECTOR_DB_NAMESPACE.LABEL') }}
+              <input
+                v-model="vectorDatabaseNamespace"
+                type="text"
+                :placeholder="$t('GENERAL_SETTINGS.FORM.VECTOR_DB_NAMESPACE.PLACEHOLDER')"
+              />
+            </label>
+          </div>
+        </div>
+
       </form>
 
       <woot-loading-state v-if="uiFlags.isFetchingItem" />

--- a/app/views/api/v1/models/_account.json.jbuilder
+++ b/app/views/api/v1/models/_account.json.jbuilder
@@ -25,3 +25,5 @@ json.name @account.name
 json.support_email @account.support_email
 json.status @account.status
 json.cache_keys @account.cache_keys
+json.shopify_name @account.shopify_name
+json.vector_database_namespace @account.vector_database_namespace

--- a/app/views/platform/api/v1/models/_account.json.jbuilder
+++ b/app/views/platform/api/v1/models/_account.json.jbuilder
@@ -7,3 +7,5 @@ json.features resource.enabled_features
 json.custom_attributes resource.custom_attributes
 json.limits resource.limits
 json.status resource.status
+json.shopify_name resource.shopify_name
+json.vector_database_namespace resource.vector_database_namespace

--- a/db/migrate/20240619000001_add_shopify_name_and_vector_database_namespace_to_accounts.rb
+++ b/db/migrate/20240619000001_add_shopify_name_and_vector_database_namespace_to_accounts.rb
@@ -1,0 +1,6 @@
+class AddShopifyNameAndVectorDatabaseNamespaceToAccounts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :accounts, :shopify_name, :string
+    add_column :accounts, :vector_database_namespace, :string
+  end
+end 

--- a/lib/webhooks/trigger.rb
+++ b/lib/webhooks/trigger.rb
@@ -40,10 +40,22 @@ class Webhooks::Trigger
   end
 
   def self.perform_request(url, payload)
+    # Get account from payload if conversation is present
+    account = nil
+    if payload[:conversation].present? && payload[:conversation][:account_id].present?
+      account = Account.find_by(id: payload[:conversation][:account_id])
+    end
+
+    # Set up headers with vector_database_namespace if available
+    headers = { 'Content-Type' => 'application/json' }
+    if account&.vector_database_namespace.present?
+      headers['X-Vector-Database-Namespace'] = account.vector_database_namespace
+    end
+
     response = HTTParty.post(
       url,
       body: payload.to_json,
-      headers: { 'Content-Type' => 'application/json' },
+      headers: headers,
       timeout: 5
     )
 
@@ -91,11 +103,23 @@ class Webhooks::Trigger
       @payload[:content_type] = @payload[:content_type].to_s
     end
     
+    # Get account from payload if conversation is present
+    account = nil
+    if @payload[:conversation].present? && @payload[:conversation][:account_id].present?
+      account = Account.find_by(id: @payload[:conversation][:account_id])
+    end
+
+    # Set up headers with vector_database_namespace if available
+    headers = { content_type: :json, accept: :json }
+    if account&.vector_database_namespace.present?
+      headers['X-Vector-Database-Namespace'] = account.vector_database_namespace
+    end
+    
     RestClient::Request.execute(
       method: :post,
       url: @url,
       payload: @payload.to_json,
-      headers: { content_type: :json, accept: :json },
+      headers: headers,
       timeout: 5
     )
   end


### PR DESCRIPTION
Here's a summary of the changes we've made:

Created a database migration to add shopify_name and vector_database_namespace fields to the accounts table Updated the Account Settings UI to include inputs for these new fields Added translations/i18n for the new fields
Updated the controllers to permit and handle these new parameters Updated the JSON views to expose these fields in the API responses Modified the webhooks trigger to include the vector database namespace in the request headers

The changes will allow users to:

Set a Shopify Name for integrations with Shopify
Configure a Vector Database Namespace for filtering vector database queries Have the Vector Database Namespace automatically included in webhook request headers for integration with external systems