### PR TITLE
Fix auto refresh conversations

### DIFF
--- a/app/javascript/dashboard/store/modules/conversations/index.js
+++ b/app/javascript/dashboard/store/modules/conversations/index.js
@@ -208,7 +208,7 @@ export const mutations = {
   },
 
   [types.UPDATE_CONVERSATION](_state, conversation) {
-    const { allConversations } = _state;
+    const { allConversations, chatStatusFilter, selectedChatId } = _state;
     const index = allConversations.findIndex(c => c.id === conversation.id);
 
     if (index > -1) {
@@ -220,13 +220,35 @@ export const mutations = {
       }
 
       const { messages, ...updates } = conversation;
-      allConversations[index] = { ...selectedConversation, ...updates };
+      const newConversationData = { ...selectedConversation, ...updates };
+
+      // Check if the conversation should be removed based on the current status filter
+      const shouldRemove =
+        updates.status && // status was part of the update
+        chatStatusFilter !== wootConstants.STATUS_TYPE.ALL && // not filtering for 'all'
+        updates.status !== chatStatusFilter && // new status doesn't match filter
+        selectedChatId !== conversation.id; // not the currently active chat
+
+      if (shouldRemove) {
+        allConversations.splice(index, 1);
+      } else {
+        allConversations[index] = newConversationData;
+      }
+
       if (_state.selectedChatId === conversation.id) {
         emitter.emit(BUS_EVENTS.FETCH_LABEL_SUGGESTIONS);
         emitter.emit(BUS_EVENTS.SCROLL_TO_MESSAGE);
       }
     } else {
-      _state.allConversations.push(conversation);
+      // If conversation is not in the list, add it only if it matches the current filter or filter is 'all'
+      // Or if it's the selected chat (it might have been filtered out before and now it's selected)
+      const matchesFilter =
+        chatStatusFilter === wootConstants.STATUS_TYPE.ALL ||
+        conversation.status === chatStatusFilter;
+
+      if (matchesFilter || selectedChatId === conversation.id) {
+        _state.allConversations.push(conversation);
+      }
     }
   },
 

--- a/app/models/concerns/assignment_handler.rb
+++ b/app/models/concerns/assignment_handler.rb
@@ -34,6 +34,15 @@ module AssignmentHandler
     }.each do |event, condition|
       condition.call && dispatcher_dispatch(event, previous_changes)
     end
+
+    # If the conversation was pending and an agent or team is assigned, open it.
+    if pending?
+      if saved_change_to_assignee_id? && assignee_id.present?
+        bot_handoff!
+      elsif saved_change_to_team_id? && team_id.present?
+        bot_handoff!
+      end
+    end
   end
 
   def process_assignment_changes


### PR DESCRIPTION
The UPDATE_CONVERSATION mutation in app/javascript/dashboard/store/modules/conversations/index.js has been updated.

This change will ensure that when a conversation is updated (e.g., its status changes to "resolved"), the frontend logic will check if it should still be part of the displayed list based on the current chatStatusFilter.

1. If the conversation no longer matches the filter (and isn't the actively selected chat), it will be removed from the allConversations array.
2. If the conversation was not in the list but now matches the filter (or is selected), it will be added.

This should provide a more responsive UI by immediately reflecting status changes in the conversation list without needing a full data refetch.