### PR TITLE
Dividing dockerfile, so the heavy lift can be saved on Docker Hub

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,37 @@
-.bundle
+# .dockerignore
+
+# Git stuff
+.git
+.gitignore
+
+# Docker stuff
+Dockerfile
+Dockerfile.base
+docker-compose.yml
+docker-compose.*.yml
+
+# Credentials and local environment
 .env
 .env.*
-docker-compose.*
-docker/Dockerfile
-docker/dockerfiles
-log
-storage
-public/system
-tmp
-.codeclimate.yml
+*.env
+
+# Ruby/Rails specifics
+log/*
+tmp/*
+public/assets
 public/packs
-node_modules
-vendor/bundle
+public/packs-test
+coverage/
+.rubocop.yml
+.rspec
+spec/
+
+# Node specifics (these are built into the base image or during assets:precompile)
+node_modules/
+.pnpm-store/ # If pnpm creates this locally and it's large
+
+# IDE & OS specific
+.vscode/
+.idea/
 .DS_Store
 *.swp
-*~

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  # Health check route - should be one of the first routes
+  # This ensures it's not caught by other wildcard routes and is easily accessible
+  get '/healthz', to: proc { [200, {}, ['OK']] }
+  
   # AUTH STARTS
   mount_devise_token_auth_for 'User', at: 'auth', controllers: {
     confirmations: 'devise_overrides/confirmations',

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ ENV RAILS_LOG_TO_STDOUT="true"
 
 WORKDIR /app
 
-COPY . . # Copy your application code on top of the base image
+COPY . .
 
 # Asset Precompilation (should already be done in my-chatwoot-base IF it was built from the full app source)
 # If my-chatwoot-base only contains dependencies, and not app code + assets, then run it here:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,70 +1,36 @@
-# Dockerfile (for Railway CI/CD)
+# Dockerfile (for Railway, using your pushed base image)
 
-# --- Build Arguments ---
-# These allow you to specify your Docker Hub username and base image tag during build.
-# Railway doesn't directly use these for *its* build, but they are good for local testing.
-# For Railway, the FROM line will be used as is.
-ARG YOUR_DOCKERHUB_USERNAME="yourdockerhubusername" # Replace with your Docker Hub username
-ARG BASE_IMAGE_TAG="latest" # Replace with your specific tag, e.g., v1.0.0
+# Directly specify the base image you pushed to Docker Hub
+FROM vkhon00/my-chatwoot-base:v1.0.0 # 
 
-# --- Base Image ---
-FROM ${YOUR_DOCKERHUB_USERNAME}/my-chatwoot-base:${BASE_IMAGE_TAG}
-
-# --- Environment Arguments and Variables ---
-# These can be overridden by Railway's service environment variables at runtime.
-# RAILS_ENV is crucial for asset precompilation.
-ARG RAILS_ENV_ARG="production"
-ARG RAILS_SERVE_STATIC_FILES_ARG="true"
-ARG EXECJS_RUNTIME_ARG="Disabled" # From your original final stage
-ARG BUNDLE_FORCE_RUBY_PLATFORM_ARG="1" # From your original final stage
-
-ENV RAILS_ENV=${RAILS_ENV_ARG}
-ENV NODE_ENV=${RAILS_ENV_ARG} # Keep NODE_ENV consistent
-ENV RAILS_SERVE_STATIC_FILES=${RAILS_SERVE_STATIC_FILES_ARG}
-ENV EXECJS_RUNTIME=${EXECJS_RUNTIME_ARG}
-ENV BUNDLE_FORCE_RUBY_PLATFORM=${BUNDLE_FORCE_RUBY_PLATFORM_ARG}
-# BUNDLE_PATH, PNPM_HOME, PATH, etc., are inherited from the base image.
+ENV RAILS_ENV="production"
+ENV NODE_ENV="production"
+ENV RAILS_SERVE_STATIC_FILES="true"
+ENV RAILS_LOG_TO_STDOUT="true"
+# Other necessary ENVs inherited or set here
 
 WORKDIR /app
 
-# --- Copy Application Code ---
-# Ensure you have a good .dockerignore file to exclude .git, tmp, local .env,
-# node_modules (already in base), vendor/bundle (already in base), etc.
-COPY . .
+COPY . . # Copy your application code on top of the base image
 
-# --- Asset Precompilation ---
-# This step runs if RAILS_ENV is production.
-# A dummy SECRET_KEY_BASE is sufficient for assets:precompile.
-# RAILS_LOG_TO_STDOUT=true helps in debugging asset compilation.
+# Asset Precompilation (should already be done in my-chatwoot-base IF it was built from the full app source)
+# If my-chatwoot-base only contains dependencies, and not app code + assets, then run it here:
 RUN if [ "$RAILS_ENV" = "production" ]; then \
     echo "Precompiling assets for production..." && \
-    SECRET_KEY_BASE_DUMMY= blanchâtre RAILS_LOG_TO_STDOUT=true bundle exec rake assets:precompile --trace && \
+    SECRET_KEY_BASE_DUMMY=temporarykey RAILS_LOG_TO_STDOUT=true bundle exec rake assets:precompile --trace && \
     echo "Asset precompilation complete." && \
-    # Clean up files not needed in the final production image after precompilation
-    # Be CAREFUL with removing ./node_modules. If any runtime JS execution (not frontend)
-    # depends on it, do not remove it. For Chatwoot, assets are typically self-contained.
     rm -rf ./tmp/cache/* ./node_modules ./spec ./app/assets/builds/*.*; \
   fi
 
-# --- Generate .git_sha ---
-# RAILWAY_GIT_COMMIT_SHA is automatically provided by Railway's build environment.
-# For local builds, you might want to pass it as a build-arg or let it default.
 ARG RAILWAY_GIT_COMMIT_SHA_ARG=${RAILWAY_GIT_COMMIT_SHA:-unknown}
 RUN echo "${RAILWAY_GIT_COMMIT_SHA_ARG}" > /app/.git_sha
 
-# --- Final Cleanup (if any specific to app code) ---
-# Most heavy cleanup (gem caches etc) is done in the base image.
-# Remove .git directory and .gitignore if they were copied by `COPY . .`
-RUN rm -rf .git .gitignore
-
-# --- Port Exposure ---
-EXPOSE 3000
-
-# --- Entrypoint & CMD ---
-# Ensure 'docker/entrypoints/rails.sh' exists in your repository at this path.
-COPY docker/entrypoints/rails.sh /usr/bin/rails.sh
+# Copy your production entrypoint script
+COPY docker/entrypoints/rails.sh /usr/bin/rails.sh # Assuming this is the rails.sh you provided
 RUN chmod +x /usr/bin/rails.sh
 
+EXPOSE 3000
+
 ENTRYPOINT ["/usr/bin/rails.sh"]
-# Default command, often overridden by the entrypoint script or Procfile.
+# This CMD will be executed by `exec "$@"` in rails.sh
 CMD ["bundle", "exec", "foreman", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 # If my-chatwoot-base only contains dependencies, and not app code + assets, then run it here:
 RUN if [ "$RAILS_ENV" = "production" ]; then \
     echo "Precompiling assets for production..." && \
-    SECRET_KEY_BASE_DUMMY=temporarykey RAILS_LOG_TO_STDOUT=true bundle exec rake assets:precompile --trace && \
+    SECRET_KEY_BASE=temporarykey_for_assets_precompile RAILS_LOG_TO_STDOUT=true bundle exec rake assets:precompile --trace && \
     echo "Asset precompilation complete." && \
     rm -rf ./tmp/cache/* ./node_modules ./spec ./app/assets/builds/*.*; \
   fi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,157 +1,70 @@
-# pre-build stage
-FROM node:23-alpine as node
-FROM ruby:3.3.3-alpine3.19 AS pre-builder
+# Dockerfile (for Railway CI/CD)
 
-ARG NODE_VERSION="23.7.0"
-ARG PNPM_VERSION="10.2.0"
-ENV NODE_VERSION=${NODE_VERSION}
-ENV PNPM_VERSION=${PNPM_VERSION}
+# --- Build Arguments ---
+# These allow you to specify your Docker Hub username and base image tag during build.
+# Railway doesn't directly use these for *its* build, but they are good for local testing.
+# For Railway, the FROM line will be used as is.
+ARG YOUR_DOCKERHUB_USERNAME="yourdockerhubusername" # Replace with your Docker Hub username
+ARG BASE_IMAGE_TAG="latest" # Replace with your specific tag, e.g., v1.0.0
 
-# ARG default to production settings
-# For development docker-compose file overrides ARGS
-ARG BUNDLE_WITHOUT="development:test"
-ENV BUNDLE_WITHOUT ${BUNDLE_WITHOUT}
-ENV BUNDLER_VERSION=2.5.11
+# --- Base Image ---
+FROM ${YOUR_DOCKERHUB_USERNAME}/my-chatwoot-base:${BASE_IMAGE_TAG}
 
-ARG RAILS_SERVE_STATIC_FILES=true
-ENV RAILS_SERVE_STATIC_FILES ${RAILS_SERVE_STATIC_FILES}
+# --- Environment Arguments and Variables ---
+# These can be overridden by Railway's service environment variables at runtime.
+# RAILS_ENV is crucial for asset precompilation.
+ARG RAILS_ENV_ARG="production"
+ARG RAILS_SERVE_STATIC_FILES_ARG="true"
+ARG EXECJS_RUNTIME_ARG="Disabled" # From your original final stage
+ARG BUNDLE_FORCE_RUBY_PLATFORM_ARG="1" # From your original final stage
 
-ARG RAILS_ENV=production
-ENV RAILS_ENV ${RAILS_ENV}
-
-ARG NODE_OPTIONS="--max-old-space-size=4096 --openssl-legacy-provider"
-ENV NODE_OPTIONS ${NODE_OPTIONS}
-
-ENV BUNDLE_PATH="/gems"
-
-RUN apk update && apk add --no-cache \
-  openssl \
-  tar \
-  build-base \
-  tzdata \
-  postgresql-dev \
-  postgresql-client \
-  git \
-  curl \
-  xz \
-  && mkdir -p /var/app \
-  && gem install bundler
-
-COPY --from=node /usr/local/bin/node /usr/local/bin/
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-  && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
-RUN npm install -g pnpm@${PNPM_VERSION}
-
-RUN echo 'export PNPM_HOME="/root/.local/share/pnpm"' >> /root/.shrc \
-  && echo 'export PATH="$PNPM_HOME:$PATH"' >> /root/.shrc \
-  && export PNPM_HOME="/root/.local/share/pnpm" \
-  && export PATH="$PNPM_HOME:$PATH" \
-  && pnpm --version
-
-# Persist the environment variables in Docker
-ENV PNPM_HOME="/root/.local/share/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV RAILS_ENV=${RAILS_ENV_ARG}
+ENV NODE_ENV=${RAILS_ENV_ARG} # Keep NODE_ENV consistent
+ENV RAILS_SERVE_STATIC_FILES=${RAILS_SERVE_STATIC_FILES_ARG}
+ENV EXECJS_RUNTIME=${EXECJS_RUNTIME_ARG}
+ENV BUNDLE_FORCE_RUBY_PLATFORM=${BUNDLE_FORCE_RUBY_PLATFORM_ARG}
+# BUNDLE_PATH, PNPM_HOME, PATH, etc., are inherited from the base image.
 
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock ./
+# --- Copy Application Code ---
+# Ensure you have a good .dockerignore file to exclude .git, tmp, local .env,
+# node_modules (already in base), vendor/bundle (already in base), etc.
+COPY . .
 
-# natively compile grpc and protobuf to support alpine musl (dialogflow-docker workflow)
-# adding xz as nokogiri was failing to build libxml
-RUN apk update && apk add --no-cache build-base musl ruby-full ruby-dev gcc make musl-dev openssl openssl-dev g++ linux-headers xz vips
-RUN bundle config set --local force_ruby_platform true
-
-# Do not install development or test gems in production
+# --- Asset Precompilation ---
+# This step runs if RAILS_ENV is production.
+# A dummy SECRET_KEY_BASE is sufficient for assets:precompile.
+# RAILS_LOG_TO_STDOUT=true helps in debugging asset compilation.
 RUN if [ "$RAILS_ENV" = "production" ]; then \
-  bundle config set without 'development test'; bundle install -j 4 -r 3; \
-  else bundle install -j 4 -r 3; \
+    echo "Precompiling assets for production..." && \
+    SECRET_KEY_BASE_DUMMY= blanchâtre RAILS_LOG_TO_STDOUT=true bundle exec rake assets:precompile --trace && \
+    echo "Asset precompilation complete." && \
+    # Clean up files not needed in the final production image after precompilation
+    # Be CAREFUL with removing ./node_modules. If any runtime JS execution (not frontend)
+    # depends on it, do not remove it. For Chatwoot, assets are typically self-contained.
+    rm -rf ./tmp/cache/* ./node_modules ./spec ./app/assets/builds/*.*; \
   fi
 
-COPY package.json pnpm-lock.yaml ./
-RUN pnpm i
+# --- Generate .git_sha ---
+# RAILWAY_GIT_COMMIT_SHA is automatically provided by Railway's build environment.
+# For local builds, you might want to pass it as a build-arg or let it default.
+ARG RAILWAY_GIT_COMMIT_SHA_ARG=${RAILWAY_GIT_COMMIT_SHA:-unknown}
+RUN echo "${RAILWAY_GIT_COMMIT_SHA_ARG}" > /app/.git_sha
 
-COPY . /app
+# --- Final Cleanup (if any specific to app code) ---
+# Most heavy cleanup (gem caches etc) is done in the base image.
+# Remove .git directory and .gitignore if they were copied by `COPY . .`
+RUN rm -rf .git .gitignore
 
-# Creating a log directory so that image won't fail when RAILS_LOG_TO_STDOUT is false.
-RUN mkdir -p /app/log
-
-# Generate production assets if production environment
-RUN if [ "$RAILS_ENV" = "production" ]; then \
-  SECRET_KEY_BASE=precompile_placeholder RAILS_LOG_TO_STDOUT=enabled bundle exec rake assets:precompile --trace \
-  && rm -rf spec node_modules tmp/cache; \
-  fi
-
-# Generate .git_sha file using the commit hash provided by the build environment
-RUN echo ${RAILWAY_GIT_COMMIT_SHA:-unknown} > /app/.git_sha
-
-# Remove unnecessary files
-RUN rm -rf /gems/ruby/3.3.0/cache/*.gem \
-  && find /gems/ruby/3.3.0/gems/ \( -name "*.c" -o -name "*.o" \) -delete \
-  && rm -rf .git \
-  && rm .gitignore
-
-# final build stage
-FROM ruby:3.3.3-alpine3.19
-
-ARG NODE_VERSION="23.7.0"
-ARG PNPM_VERSION="10.2.0"
-ENV NODE_VERSION=${NODE_VERSION}
-ENV PNPM_VERSION=${PNPM_VERSION}
-
-ARG BUNDLE_WITHOUT="development:test"
-ENV BUNDLE_WITHOUT ${BUNDLE_WITHOUT}
-ENV BUNDLER_VERSION=2.5.11
-
-ARG EXECJS_RUNTIME="Disabled"
-ENV EXECJS_RUNTIME ${EXECJS_RUNTIME}
-
-ARG RAILS_SERVE_STATIC_FILES=true
-ENV RAILS_SERVE_STATIC_FILES ${RAILS_SERVE_STATIC_FILES}
-
-ARG BUNDLE_FORCE_RUBY_PLATFORM=1
-ENV BUNDLE_FORCE_RUBY_PLATFORM ${BUNDLE_FORCE_RUBY_PLATFORM}
-
-ARG RAILS_ENV=production
-ENV RAILS_ENV ${RAILS_ENV}
-ENV BUNDLE_PATH="/gems"
-
-RUN apk update && apk add --no-cache \
-  build-base \
-  openssl \
-  tzdata \
-  postgresql-client \
-  imagemagick \
-  git \
-  vips \
-  && gem install bundler
-
-COPY --from=node /usr/local/bin/node /usr/local/bin/
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
-
-RUN if [ "$RAILS_ENV" != "production" ]; then \
-  apk add --no-cache curl \
-  && ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-  && ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
-  && npm install -g pnpm@${PNPM_VERSION} \
-  && pnpm --version; \
-  fi
-
-COPY --from=pre-builder /gems/ /gems/
-COPY --from=pre-builder /app /app
-
-# Copy .git_sha file from pre-builder stage
-COPY --from=pre-builder /app/.git_sha /app/.git_sha
-
-WORKDIR /app
-
+# --- Port Exposure ---
 EXPOSE 3000
 
-# Copy and set up the rails.sh script as the entrypoint
+# --- Entrypoint & CMD ---
+# Ensure 'docker/entrypoints/rails.sh' exists in your repository at this path.
 COPY docker/entrypoints/rails.sh /usr/bin/rails.sh
 RUN chmod +x /usr/bin/rails.sh
 
 ENTRYPOINT ["/usr/bin/rails.sh"]
-
+# Default command, often overridden by the entrypoint script or Procfile.
 CMD ["bundle", "exec", "foreman", "start"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ ARG RAILWAY_GIT_COMMIT_SHA_ARG=${RAILWAY_GIT_COMMIT_SHA:-unknown}
 RUN echo "${RAILWAY_GIT_COMMIT_SHA_ARG}" > /app/.git_sha
 
 # Copy your production entrypoint script
-COPY entrypoints/rails.sh /usr/bin/rails.sh # Assuming this is the rails.sh you provided
+COPY entrypoints/rails.sh /usr/bin/rails.sh
 RUN chmod +x /usr/bin/rails.sh
 
 EXPOSE 3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile (for Railway, using your pushed base image)
 
 # Directly specify the base image you pushed to Docker Hub
-FROM vkhon00/my-chatwoot-base:v1.0.0
+FROM vkhon00/my-chatwoot-base:v1.0.1
 
 ENV RAILS_ENV="production"
 ENV NODE_ENV="production"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ ARG RAILWAY_GIT_COMMIT_SHA_ARG=${RAILWAY_GIT_COMMIT_SHA:-unknown}
 RUN echo "${RAILWAY_GIT_COMMIT_SHA_ARG}" > /app/.git_sha
 
 # Copy your production entrypoint script
-COPY entrypoints/rails.sh /usr/bin/rails.sh
+COPY docker/entrypoints/rails.sh /usr/bin/rails.sh
 RUN chmod +x /usr/bin/rails.sh
 
 EXPOSE 3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ ARG RAILWAY_GIT_COMMIT_SHA_ARG=${RAILWAY_GIT_COMMIT_SHA:-unknown}
 RUN echo "${RAILWAY_GIT_COMMIT_SHA_ARG}" > /app/.git_sha
 
 # Copy your production entrypoint script
-COPY docker/entrypoints/rails.sh /usr/bin/rails.sh # Assuming this is the rails.sh you provided
+COPY entrypoints/rails.sh /usr/bin/rails.sh # Assuming this is the rails.sh you provided
 RUN chmod +x /usr/bin/rails.sh
 
 EXPOSE 3000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile (for Railway, using your pushed base image)
 
 # Directly specify the base image you pushed to Docker Hub
-FROM vkhon00/my-chatwoot-base:v1.0.0 # 
+FROM vkhon00/my-chatwoot-base:v1.0.0
 
 ENV RAILS_ENV="production"
 ENV NODE_ENV="production"

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -70,18 +70,21 @@ RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
 WORKDIR /app
 
 # --- Install Gems ---
-COPY Gemfile Gemfile.lock ./
-# If you have Gemfile.Enterprise or similar, copy it too
-# COPY Gemfile.Enterprise ./
-
-RUN bundle config set --local force_ruby_platform true \
-    && bundle config set without ${BUNDLE_WITHOUT} \
-    # Using nproc for job count
-    && bundle install --jobs "$(nproc)" --retry 3 \
-    # Clean up bundle cache to reduce image size
-    && rm -rf $BUNDLE_PATH/ruby/*/cache/*.gem \
-    && find $BUNDLE_PATH/ruby/*/gems/ \( -name "*.c" -o -name "*.o" -o -name "*.so" \) -delete \
-    && find $BUNDLE_PATH/ruby/*/extensions -name "*.o" -delete
+    COPY Gemfile Gemfile.lock ./
+    RUN bundle config set --local force_ruby_platform true \
+        && bundle config set without ${BUNDLE_WITHOUT} \
+        && bundle install --jobs "$(nproc)" --retry 3 \
+        # More targeted cleanup:
+        # Remove .gem cache files
+        && rm -rf $BUNDLE_PATH/ruby/*/cache/*.gem \
+        # Remove C and object files from the gems' C extension build directories,
+        # but NOT the final .so files usually found in gem's lib or linked from extensions dir.
+        && find $BUNDLE_PATH/ruby/*/gems/ -type f \( -name "*.c" -o -name "*.o" \) -delete \
+        # Also remove from specific extension build directories, which is often deeper
+        && find $BUNDLE_PATH/ruby/*/extensions/ -type f \( -name "*.c" -o -name "*.o" \) -delete \
+        # Clean up empty directories that might be left after deleting .c/.o files
+        && find $BUNDLE_PATH/ruby/*/gems/ -type d -empty -delete \
+        && find $BUNDLE_PATH/ruby/*/extensions/ -type d -empty -delete
 
 # --- Install PNPM Packages ---
 COPY package.json pnpm-lock.yaml ./

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,0 +1,103 @@
+# Dockerfile.base
+# This image contains OS dependencies, Ruby, Node, PNPM,
+# installed gems, and installed pnpm packages.
+
+# ----- Stage 1: Node Source (to get a specific Node version consistently) -----
+FROM node:23-alpine AS node_source
+# No further action needed in this stage, just using it as a source for Node bits.
+
+# ----- Stage 2: Base Builder & Runtime Dependencies -----
+FROM ruby:3.3.3-alpine3.19
+
+# --- Environment Arguments and Variables ---
+# Use _ARG suffix for build-time args to avoid clashes with ENVs if set later
+ARG NODE_VERSION_ARG="23.7.0"
+ARG PNPM_VERSION_ARG="10.2.0"
+ARG BUNDLER_VERSION_ARG="2.5.11"
+
+ENV NODE_VERSION=${NODE_VERSION_ARG}
+ENV PNPM_VERSION=${PNPM_VERSION_ARG}
+ENV BUNDLER_VERSION=${BUNDLER_VERSION_ARG}
+
+# Default ENVs for the base image (can be overridden by Railway at runtime for the final image)
+ENV RAILS_ENV="production"
+ENV NODE_ENV="production"
+ENV BUNDLE_WITHOUT="development:test"
+ENV NODE_OPTIONS="--max-old-space-size=4096 --openssl-legacy-provider"
+ENV BUNDLE_PATH="/gems"
+ENV BUNDLE_BIN="$BUNDLE_PATH/bin"
+ENV GEM_HOME=$BUNDLE_PATH
+ENV GEM_PATH=$BUNDLE_PATH
+
+ENV PNPM_HOME="/root/.local/share/pnpm"
+ENV PATH="${PNPM_HOME}:${BUNDLE_BIN}:/usr/local/bin:${PATH}"
+
+# --- Install System & Build Dependencies ---
+# Combining dependencies from your original pre-builder and final stage
+# to ensure this base has everything for building and running.
+RUN apk update && apk add --no-cache \
+    build-base \
+    tzdata \
+    postgresql-dev \
+    postgresql-client \
+    git \
+    curl \
+    xz \
+    # For grpc/protobuf/nokogiri/vips
+    musl-dev \
+    # ruby-dev is usually part of ruby:<version>-dev, but ruby:<version>-alpine might need it explicitly for native extensions.
+    # ruby-full is not typically needed if using the official ruby image.
+    # gcc make g++ linux-headers are part of build-base or implicitly available.
+    openssl \
+    openssl-dev \
+    vips \
+    imagemagick \
+    && rm -rf /var/cache/apk/*
+
+# --- Install Bundler ---
+RUN gem install bundler -v "${BUNDLER_VERSION}" --no-document \
+    && bundle config --global silence_root_warning 1
+
+# --- Install Node.js & PNPM ---
+COPY --from=node_source /usr/local/bin/node /usr/local/bin/
+COPY --from=node_source /usr/local/lib/node_modules /usr/local/lib/node_modules
+# Create symlinks for npm and npx if they are not already there (they should be with node_modules copy)
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && npm install -g pnpm@${PNPM_VERSION} \
+    && pnpm --version # Verify pnpm installation
+
+WORKDIR /app
+
+# --- Install Gems ---
+COPY Gemfile Gemfile.lock ./
+# If you have Gemfile.Enterprise or similar, copy it too
+# COPY Gemfile.Enterprise ./
+
+RUN bundle config set --local force_ruby_platform true \
+    && bundle config set without ${BUNDLE_WITHOUT} \
+    # Using nproc for job count
+    && bundle install --jobs "$(nproc)" --retry 3 \
+    # Clean up bundle cache to reduce image size
+    && rm -rf $BUNDLE_PATH/ruby/*/cache/*.gem \
+    && find $BUNDLE_PATH/ruby/*/gems/ \( -name "*.c" -o -name "*.o" -o -name "*.so" \) -delete \
+    && find $BUNDLE_PATH/ruby/*/extensions -name "*.o" -delete
+
+# --- Install PNPM Packages ---
+COPY package.json pnpm-lock.yaml ./
+# If you have a monorepo structure with pnpm-workspace.yaml, copy that too
+# COPY pnpm-workspace.yaml ./
+# Copy client/package.json etc. if they exist and are part of the workspace
+# COPY client/package.json client/yarn.lock ./client/
+
+# Use --frozen-lockfile for CI/production builds to ensure it uses the lockfile strictly
+# --prod might be suitable if devDependencies are not needed for any build steps within pnpm
+RUN pnpm install --frozen-lockfile
+# Optional: pnpm store prune # To clean up the pnpm cache if it gets too large
+
+# --- Create essential directories ---
+RUN mkdir -p /app/log \
+    && mkdir -p /app/tmp/pids
+
+# --- Base image definition stops here ---
+# Application code, asset precompilation, final entrypoint setup will be in the next Dockerfile.

--- a/docker/entrypoints/rails.sh
+++ b/docker/entrypoints/rails.sh
@@ -1,49 +1,48 @@
 #!/bin/sh
-set -x
+set -x # Keep for debugging on Railway for now
 
 # Remove any pre-existing server.pid and clear cache.
 rm -rf /app/tmp/pids/server.pid
-rm -rf /app/tmp/cache/*
+# rm -rf /app/tmp/cache/* # Clearing cache here might be too aggressive if assets are precompiled
 
 echo "Waiting for postgres to become ready...."
-
-# If DATABASE_URL is set, parse out connection details.
 if [ -n "$DATABASE_URL" ]; then
-  echo "DATABASE_URL found: $DATABASE_URL"
-  # For example, if DATABASE_URL is in the form postgres://username:password@host:port/dbname,
-  # extract host, port, and username.
   export POSTGRES_HOST=$(echo "$DATABASE_URL" | sed -n 's#.*@\([^:/]\+\).*#\1#p')
   export POSTGRES_PORT=$(echo "$DATABASE_URL" | sed -n 's#.*:\([0-9]\+\)/.*#\1#p')
   export POSTGRES_USERNAME=$(echo "$DATABASE_URL" | sed -n 's#.*//\([^:]*\):.*#\1#p')
 fi
 
-# Debug output – remove in production if needed.
 echo "Parsed POSTGRES_HOST: $POSTGRES_HOST"
 echo "Parsed POSTGRES_PORT: $POSTGRES_PORT"
 echo "Parsed POSTGRES_USERNAME: $POSTGRES_USERNAME"
 
-# Construct the pg_isready command.
-PG_READY="pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USERNAME"
+if [ -n "$POSTGRES_HOST" ] && [ -n "$POSTGRES_PORT" ] && [ -n "$POSTGRES_USERNAME" ]; then
+  PG_READY="pg_isready -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USERNAME"
+  until $PG_READY; do
+    echo "Postgres is unavailable - sleeping"
+    sleep 2
+  done
+  echo "Database ready to accept connections."
+else
+  echo "PostgreSQL connection details not fully available. Skipping pg_isready check."
+fi
 
-# Wait until the database is ready.
-until $PG_READY; do
-  sleep 2
-done
-
-echo "Database ready to accept connections."
-
-# Install any missing gems.
-bundle install
+# Gems should already be installed in the base image.
+# bundle install # REMOVE THIS LINE
 
 # Ensure gems are available.
-BUNDLE="bundle check"
-until $BUNDLE; do
-  sleep 2
-done
+# BUNDLE="bundle check" # This can still be useful
+# until $BUNDLE; do
+#  echo "Bundle check failed - sleeping" # Should not happen if base image is correct
+#  sleep 2
+# done
+# echo "Bundle check successful." #
 
-echo "Running database migrations..."
+echo "Running database migrations (db:chatwoot_prepare)..."
 bundle exec rails db:chatwoot_prepare
 
-mkdir -p /app/tmp/pids
+# mkdir -p /app/tmp/pids # This should already exist or be created by puma/foreman
+
 # Finally, execute the main process (passed as CMD)
+echo "Executing CMD: $@"
 exec "$@"


### PR DESCRIPTION
- Divide dockerfile into 2, and create dockerfile.base
- Dockerfile.base is used locally by Docker to create an image, that can then be used to push to Docker Hub
- In Railway.com, Chatwoot service can still be used with GitHub, which will automatically use the built image from Docker Hub, which should reduce the build time by about 2 minutes for each deployment

- In order to build a local image for docker use: docker build -f docker/Dockerfile.base -t vkhon00/my-chatwoot-base:v1.0.1 .

- Increase the version number anytime there is a change to the actual dependencies or core files, and push it to Docker Hub
- Once the version in increased, need to also manually increase the version on the dockerfile to point to the latest version
- Note, when pushing to Docker Hub, it may take close to 20 minutes