### PR TITLE
Feat enable redis to be picked up by n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ This version includes enhanced webhook functionality for better tracking visitor
 
 Detailed documentation is available at [chatwoot.com/help-center](https://www.chatwoot.com/help-center).
 
+### Redis Configuration
+
+Chatwoot uses Redis for caching, background jobs, and real-time features. For proper functionality, ensure your Redis/Valkey instance has keyspace notifications enabled for expired events:
+
+```
+notify-keyspace-events Ex
+```
+
+See [Redis Configuration](docs/redis-configuration.md) for more details.
+
 ## Translation process
 
 The translation process for Chatwoot web and mobile app is managed at [https://translate.chatwoot.com](https://translate.chatwoot.com) using Crowdin. Please read the [translation guide](https://www.chatwoot.com/docs/contributing/translating-chatwoot-to-your-language) for contributing to Chatwoot.

--- a/config/initializers/02_redis_keyspace.rb
+++ b/config/initializers/02_redis_keyspace.rb
@@ -1,0 +1,22 @@
+# Configure Redis keyspace notifications for expired events
+# This is necessary for features that need to listen to key expiration events
+
+unless Rails.env.test?
+  Rails.application.config.after_initialize do
+    # Configure the main Redis instances
+    begin
+      # Get the keyspace notification setting from environment variable or use 'Ex' by default
+      # Ex = Keyevent notifications for expired events
+      keyspace_setting = ENV.fetch('REDIS_KEYSPACE_NOTIFICATIONS', 'Ex')
+      
+      # Use a separate connection to set the config to avoid disrupting pooled connections
+      redis = Redis.new(Redis::Config.app)
+      redis.config('SET', 'notify-keyspace-events', keyspace_setting)
+      redis.close
+      
+      Rails.logger.info "Redis keyspace notifications configured with: #{keyspace_setting}"
+    rescue => e
+      Rails.logger.error "Failed to configure Redis keyspace notifications: #{e.message}"
+    end
+  end
+end 

--- a/docs/redis-configuration.md
+++ b/docs/redis-configuration.md
@@ -4,15 +4,16 @@ This document covers Redis configuration settings used in Chatwoot.
 
 ## Keyspace Notifications
 
-Chatwoot uses Redis keyspace notifications for tracking expired events. This is configured in the `lib/redis/config.rb` file.
+Chatwoot uses Redis keyspace notifications for tracking expired events. This is configured in the `config/initializers/02_redis_keyspace.rb` initializer.
 
 ### Configuration
 
 By default, Chatwoot enables keyspace notifications for expired events (`Ex`). This is controlled by the `REDIS_KEYSPACE_NOTIFICATIONS` environment variable.
 
 ```ruby
-# In lib/redis/config.rb
-keyspace_notifications: ENV.fetch('REDIS_KEYSPACE_NOTIFICATIONS', 'Ex')
+# In config/initializers/02_redis_keyspace.rb
+keyspace_setting = ENV.fetch('REDIS_KEYSPACE_NOTIFICATIONS', 'Ex')
+redis.config('SET', 'notify-keyspace-events', keyspace_setting)
 ```
 
 ### Setting up in your environment
@@ -24,12 +25,12 @@ If you're using Valkey (or Redis), ensure your configuration has keyspace notifi
    notify-keyspace-events Ex
    ```
 
-2. If you're using environment variables, you can set:
+2. If you're using environment variables with Chatwoot, you can set:
    ```
    REDIS_KEYSPACE_NOTIFICATIONS=Ex
    ```
 
-3. Make sure to restart your Redis/Valkey instance after changing configurations.
+3. Make sure to restart your Redis/Valkey instance after changing configurations directly in the configuration file.
 
 ### Available Notification Options
 

--- a/docs/redis-configuration.md
+++ b/docs/redis-configuration.md
@@ -1,0 +1,56 @@
+# Redis Configuration in Chatwoot
+
+This document covers Redis configuration settings used in Chatwoot.
+
+## Keyspace Notifications
+
+Chatwoot uses Redis keyspace notifications for tracking expired events. This is configured in the `lib/redis/config.rb` file.
+
+### Configuration
+
+By default, Chatwoot enables keyspace notifications for expired events (`Ex`). This is controlled by the `REDIS_KEYSPACE_NOTIFICATIONS` environment variable.
+
+```ruby
+# In lib/redis/config.rb
+keyspace_notifications: ENV.fetch('REDIS_KEYSPACE_NOTIFICATIONS', 'Ex')
+```
+
+### Setting up in your environment
+
+If you're using Valkey (or Redis), ensure your configuration has keyspace notifications enabled for expired events:
+
+1. In your `valkey.conf` (or `redis.conf`), add or set:
+   ```
+   notify-keyspace-events Ex
+   ```
+
+2. If you're using environment variables, you can set:
+   ```
+   REDIS_KEYSPACE_NOTIFICATIONS=Ex
+   ```
+
+3. Make sure to restart your Redis/Valkey instance after changing configurations.
+
+### Available Notification Options
+
+Redis keyspace notification options:
+- `K` - Keyspace events, published with `__keyspace@<db>__` prefix
+- `E` - Keyevent events, published with `__keyevent@<db>__` prefix
+- `g` - Generic commands (non-type specific) like DEL, EXPIRE, etc.
+- `$` - String commands
+- `l` - List commands
+- `s` - Set commands
+- `h` - Hash commands
+- `z` - Sorted set commands
+- `t` - Stream commands
+- `d` - Module key type events
+- `x` - Expired events (events generated when a key expires)
+- `e` - Evicted events (events generated when a key is evicted for maxmemory)
+- `m` - Key miss events (events generated when a key that doesn't exist is accessed)
+- `A` - Alias for "g$lshztxed", all the commands
+
+For detailed information, refer to [Redis Keyspace Notifications documentation](https://redis.io/docs/manual/keyspace-notifications/).
+
+### Using Keyspace Notifications
+
+When a key expires, Redis will publish a message to the `__keyevent@<db>__:expired` channel. You can subscribe to this channel to receive notifications when keys expire. 

--- a/lib/redis/config.rb
+++ b/lib/redis/config.rb
@@ -16,9 +16,7 @@ module Redis::Config
         ssl_params: { verify_mode: Chatwoot.redis_ssl_verify_mode },
         reconnect_attempts: 2,
         timeout: 1,
-        driver: :ruby,
-        # Enable keyspace notifications for expired events
-        keyspace_notifications: ENV.fetch('REDIS_KEYSPACE_NOTIFICATIONS', 'Ex')
+        driver: :ruby
       }
     end
 

--- a/lib/redis/config.rb
+++ b/lib/redis/config.rb
@@ -15,7 +15,10 @@ module Redis::Config
         password: ENV.fetch('REDIS_PASSWORD', nil).presence,
         ssl_params: { verify_mode: Chatwoot.redis_ssl_verify_mode },
         reconnect_attempts: 2,
-        timeout: 1
+        timeout: 1,
+        driver: :ruby,
+        # Enable keyspace notifications for expired events
+        keyspace_notifications: ENV.fetch('REDIS_KEYSPACE_NOTIFICATIONS', 'Ex')
       }
     end
 


### PR DESCRIPTION
- Enable Redix expiring events to be picked up by Redis Trigger in N8N
- This allows N8N to pick up messages coming from the user, wait for a few seconds. If there are multiple messages coming at the same time, then N8N will combine all messages and process them together
- This adds a short delay to the user, but hopefully it will be an overall better experience